### PR TITLE
FileSystemWatcher alternative

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -64,10 +64,16 @@ public class DevToolsProperties {
 				+ "**/*Test.class,**/*Tests.class,git.properties,META-INF/build-info.properties";
 
 		/**
-		 * Whether to enable automatic restart.
+		 * Enable automatic restart.
 		 */
 		private boolean enabled = true;
+		
 
+		/**
+		 * Use asynchronous java.nio API instead of monitoring in intervals.
+		 */
+		private boolean nio = false;
+		
 		/**
 		 * Patterns that should be excluded from triggering a full restart.
 		 */
@@ -90,8 +96,8 @@ public class DevToolsProperties {
 		private Duration quietPeriod = Duration.ofMillis(400);
 
 		/**
-		 * Name of a specific file that, when changed, triggers the restart check. If not
-		 * specified, any classpath file change will trigger the restart.
+		 * Name of a specific file that when changed will trigger the restart check. If
+		 * not specified any classpath file change will trigger the restart.
 		 */
 		private String triggerFile;
 
@@ -106,6 +112,14 @@ public class DevToolsProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public boolean isNio() {
+			return nio;
+		}
+
+		public void setNio(boolean nio) {
+			this.nio = nio;
 		}
 
 		public String[] getAllExclude() {
@@ -176,7 +190,7 @@ public class DevToolsProperties {
 	public static class Livereload {
 
 		/**
-		 * Whether to enable a livereload.com-compatible server.
+		 * Enable a livereload.com compatible server.
 		 */
 		private boolean enabled = true;
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcher.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.devtools.filewatch;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.devtools.filewatch.ChangedFile.Type;
+import org.springframework.boot.devtools.remote.client.ClassPathChangeUploader;
+import org.springframework.util.Assert;
+
+/**
+ * Starts a thread to monitor source directories using java.nio package.
+ * 
+ * @author Damian Suchodolski
+ *
+ */
+public class FileSystemNIOWatcher extends FileSystemWatcher implements FileWatcher {
+
+	private static final int DEFAULT_TIMER_DELAY = 100;
+
+	private static final Log logger = LogFactory.getLog(ClassPathChangeUploader.class);
+
+	private final List<FileChangeListener> listeners = new ArrayList<>();
+
+	private final Object addMonitor = new Object();
+	private final Object closeMonitor = new Object();
+
+	private final List<Path> registeredFolders = new LinkedList<Path>();
+
+	private AtomicBoolean running = new AtomicBoolean(false);
+
+	private Timer timer;
+
+	private FileFilter triggerFilter;
+
+	private final Map<WatchKey, Path> watchKeyPathMap = new HashMap<WatchKey, Path>();
+
+	private Map<Path, WatchKey> watchPathKeyMap = new HashMap<Path, WatchKey>();
+
+	private WatchService watchService;
+
+	private Thread watchThread;
+
+	private int pollIntervalMs = DEFAULT_TIMER_DELAY;
+
+	private final int quietPeriodMs;
+
+	public FileSystemNIOWatcher(Duration pollInterval, Duration quietPeriod) {
+		logger.debug("new FileSystemListener");
+
+		Assert.notNull(pollInterval, "PollInterval must not be null");
+		Assert.notNull(quietPeriod, "QuietPeriod must not be null");
+		Assert.isTrue(pollInterval.toMillis() > 0, "PollInterval must be positive");
+		Assert.isTrue(quietPeriod.toMillis() >= 0, "QuietPeriod must be positive");
+		Assert.isTrue(pollInterval.toMillis() < Integer.MAX_VALUE,
+				"PollInterval must be smaller than " + Integer.MAX_VALUE);
+		Assert.isTrue(quietPeriod.toMillis() < Integer.MAX_VALUE,
+				"QuietPeriod must be smaller than " + Integer.MAX_VALUE);
+
+		this.pollIntervalMs = (int) pollInterval.toMillis();
+		this.quietPeriodMs = (int) quietPeriod.toMillis();
+
+		logger.debug("pollIntervalMs :" + pollIntervalMs + ", quietPeriodMs :"
+				+ quietPeriodMs);
+
+	}
+
+	@Override
+	public void addListener(FileChangeListener fileChangeListener) {
+		Assert.notNull(fileChangeListener, "FileChangeListener must not be null");
+		synchronized (this.addMonitor) {
+			logger.debug("new FileChangeListener " + fileChangeListener);
+			this.listeners.add(fileChangeListener);
+		}
+	}
+
+	@Override
+	public void addSourceFolder(File folder) {
+		Assert.notNull(folder, "Folder must not be null");
+		Assert.isTrue(folder.isDirectory(),
+				"Folder '" + folder + "' must exist and must" + " be a directory");
+		logger.debug("new source folder " + folder);
+		registeredFolders.add(folder.toPath());
+	}
+
+	@Override
+	public void addSourceFolders(Iterable<File> folders) {
+		Assert.notNull(folders, "Folders must not be null");
+		synchronized (this.addMonitor) {
+			for (File folder : folders) {
+				addSourceFolder(folder);
+			}
+		}
+	}
+
+	private void fireListeners(Set<ChangedFiles> changeSet) {
+		if (this.listeners == null) {
+			return;
+		}
+		for (FileChangeListener listener : this.listeners) {
+			listener.onChange(changeSet);
+		}
+	}
+
+	private boolean acceptChangedFile(Path dir) {
+		boolean accept = (triggerFilter == null || !triggerFilter.accept(dir.toFile()));
+		if (!accept) {
+			logger.debug("Skip file : " + dir);
+		}
+		return accept;
+	}
+
+	private boolean isRecursiveEnabled() {
+		return true;
+	}
+
+	private synchronized void registerWatch(Path dir) {
+
+		logger.debug("Registering a path " + dir);
+		if (!watchPathKeyMap.containsKey(dir)) {
+			// Need to refresh key?
+			try {
+				WatchKey watchKey = dir.register(watchService, ENTRY_CREATE, ENTRY_DELETE,
+						ENTRY_MODIFY);
+				watchPathKeyMap.put(dir, watchKey);
+				watchKeyPathMap.put(watchKey, dir);
+			}
+			catch (IOException e) {
+			}
+		}
+	}
+
+	@Override
+	public void setTriggerFilter(FileFilter triggerFilter) {
+		synchronized (this.addMonitor) {
+			this.triggerFilter = triggerFilter;
+		}
+	}
+
+	@Override
+	public void start() {
+		logger.debug("Starting watchThread ...");
+		synchronized (closeMonitor) {
+			watchThread = new Thread(new Runnable() {
+				@Override
+				public void run() {
+					running.set(true);
+					watchLoop();
+				}
+			}, "FileSystemListener");
+			watchThread.start();
+		}
+	}
+
+	public boolean isAlive() {
+		if (watchThread == null) {
+			return false;
+		}
+		return watchThread.isAlive();
+	}
+
+	@Override
+	public void stop() {
+
+		logger.debug("Closing watcher ...");
+		synchronized (closeMonitor) {
+			if (watchThread != null) {
+				try {
+					running.set(false);
+					watchService.close();
+					watchThread.interrupt();
+				}
+				catch (IOException e) {
+					logger.debug("Problem clising watchThread", e);
+				}
+			}
+		}
+
+	}
+
+	private synchronized void unregisterInvalidPaths() {
+		Set<Path> paths = new HashSet<Path>(watchPathKeyMap.keySet());
+		Set<Path> invalidPaths = new HashSet<Path>();
+
+		for (Path path : paths) {
+			if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+				invalidPaths.add(path);
+			}
+		}
+		if (invalidPaths.size() > 0) {
+			logger.debug("Removing invalid paths");
+			for (Path path : invalidPaths) {
+				unregisterWatch(path);
+			}
+		}
+	}
+
+	private synchronized void unregisterWatch(Path dir) {
+		WatchKey watchKey = watchPathKeyMap.get(dir);
+
+		if (watchKey != null) {
+			watchKey.cancel();
+			watchPathKeyMap.remove(dir);
+		}
+	}
+
+	/**
+	 * Register directories to watch recursively
+	 * @param path
+	 * @throws IOException
+	 */
+	private synchronized void walkTreeAndSetWatches(Path path) throws IOException {
+
+		if (acceptChangedFile(path)) {
+			Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult preVisitDirectory(Path dir,
+						BasicFileAttributes attrs) throws IOException {
+					if (!acceptChangedFile(dir)) {
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+					else {
+						registerWatch(dir);
+						return FileVisitResult.CONTINUE;
+					}
+				}
+			});
+		}
+	}
+
+	private void watchLoop() {
+		try {
+			watchService = FileSystems.getDefault().newWatchService();
+		}
+		catch (IOException e) {
+			logger.error("IO exception", e);
+		}
+
+		for (Path path : registeredFolders) {
+			try {
+				logger.debug("Initialize watched folder set");
+				walkTreeAndSetWatches(path);
+			}
+			catch (IOException e) {
+				logger.warn("Can't register a path", e);
+			}
+		}
+
+		if (this.quietPeriodMs > 0) {
+			try {
+				Thread.sleep(this.quietPeriodMs);
+			}
+			catch (InterruptedException e) {
+				logger.trace("Quiet period sleep interrupted");
+			}
+		}
+
+		while (running.get()) {
+			try {
+				logger.debug("WatchThread waiting...");
+				WatchKey watchKey = watchService.take();
+				List<WatchEvent<?>> pollEvents = watchKey.pollEvents();
+
+				synchronized (closeMonitor) {
+					if (running.get()) {
+
+						for (WatchEvent<?> event : pollEvents) {
+
+							logger.debug("New event : " + event);
+
+							if (event.context() instanceof Path) {
+
+								Kind<?> kind = event.kind();
+
+								if (kind == OVERFLOW) {
+									continue;
+								}
+
+								Path watchPath = watchKeyPathMap.get(watchKey);
+
+								if (watchPath == null) {
+									logger.debug("watch key is null " + watchKey);
+									break;
+								}
+
+								Path eventPath = (Path) event.context();
+								Path path = watchPath.resolve(eventPath);
+								File file = path.toFile();
+
+								logger.debug("New event : " + kind + ", eventPath : "
+										+ eventPath + ", path: " + path);
+
+								if (!acceptChangedFile(path)) {
+									continue;
+								}
+
+								boolean isDirectory = file.isDirectory();
+
+								if (timer != null) {
+									timer.cancel();
+									timer = null;
+								}
+
+								timer = new Timer("WatchTimer");
+								timer.schedule(new TimerTask() {
+									@Override
+									public void run() {
+
+										if (kind == ENTRY_CREATE) {
+											if (isDirectory) {
+												if (isRecursiveEnabled()) {
+													try {
+														walkTreeAndSetWatches(path);
+													}
+													catch (IOException e) {
+														logger.warn(
+																"Can't register new folder",
+																e);
+													}
+												}
+											}
+										}
+
+										Type type = assignEventType(kind);
+
+										// too many objects?
+										Set<ChangedFile> changes = new LinkedHashSet<>();
+										ChangedFiles changedFiles = new ChangedFiles(
+												watchPath.toFile(), changes);
+										Set<ChangedFiles> changedFilesSet = new HashSet<ChangedFiles>();
+										changedFilesSet.add(changedFiles);
+
+										logger.debug("Changed file : " + eventPath + ", "
+												+ watchPath + ", " + file);
+										ChangedFile changedFile = new ChangedFile(
+												watchPath.toFile(), file, type);
+										changes.add(changedFile);
+
+										fireListeners(Collections
+												.unmodifiableSet(changedFilesSet));
+
+										boolean valid = watchKey.reset();
+										if (!valid) {
+											watchKeyPathMap.remove(watchKey);
+										}
+
+										unregisterInvalidPaths();
+
+									}
+
+									private Type assignEventType(Kind<?> kind) {
+										Type type = null;
+										if (kind.equals(ENTRY_MODIFY)) {
+											type = Type.MODIFY;
+										}
+										else if (kind.equals(ENTRY_DELETE)) {
+											type = Type.DELETE;
+										}
+										else if (kind.equals(ENTRY_CREATE)) {
+											type = Type.ADD;
+										}
+										else {
+											logger.warn(
+													"Invalid watch event type " + type);
+										}
+										return type;
+									}
+
+								}, pollIntervalMs);
+							}
+
+						}
+					}
+				}
+			}
+			catch (InterruptedException | ClosedWatchServiceException e) {
+				logger.debug("Stopping watcher");
+				logger.trace("Stopping watcher exception", e);
+				stop();
+			}
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileWatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.devtools.filewatch;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+
+/**
+ * Allows to watch for changes in source directories
+ * 
+ * @author Damian Suchodolski
+ *
+ */
+public interface FileWatcher {
+
+	/**
+	 * Add listener for file change events. Cannot be called after the watcher has been
+	 * {@link #start() started}.
+	 * @param fileChangeListener the listener to add
+	 */
+	void addListener(FileChangeListener fileChangeListener);
+
+	/**
+	 * Add source folders to monitor. Cannot be called after the watcher has been
+	 * {@link #start() started}.
+	 * @param folders the folders to monitor
+	 */
+	void addSourceFolders(Iterable<File> folders);
+
+	/**
+	 * Add a source folder to monitor. Cannot be called after the watcher has been
+	 * {@link #start() started}.
+	 * @param folder the folder to monitor
+	 */
+	void addSourceFolder(File folder);
+
+	/**
+	 * Set an optional {@link FileFilter} used to limit the files that trigger a change.
+	 * @param triggerFilter a trigger filter or null
+	 */
+	void setTriggerFilter(FileFilter triggerFilter);
+
+	/**
+	 * Start monitoring the source folder for changes.
+	 * @throws IOException
+	 */
+	void start();
+
+	/**
+	 * Stop monitoring the source folders.
+	 */
+	void stop();
+
+}

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcherTest.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcherTest.java
@@ -1,0 +1,111 @@
+package org.springframework.boot.devtools.filewatch;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.boot.devtools.filewatch.ChangedFile.Type;
+import org.springframework.boot.devtools.remote.client.ClassPathChangeUploader;
+import org.springframework.util.FileCopyUtils;
+
+public class FileSystemNIOWatcherTest {
+
+	private static final Log logger = LogFactory.getLog(ClassPathChangeUploader.class);
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testStartStopThread() throws Exception {
+		CountDownLatch lock = new CountDownLatch(1);
+		FileSystemNIOWatcher watcher = new FileSystemNIOWatcher(Duration.ofMillis(10),
+				Duration.ofMillis(0));
+		watcher.addSourceFolder(temporaryFolder.getRoot());
+		assertTrue(!watcher.isAlive());
+		watcher.start();
+		lock.await(10, TimeUnit.MILLISECONDS);
+		assertTrue(watcher.isAlive());
+		watcher.stop();
+		lock.await(10, TimeUnit.MILLISECONDS);
+		assertTrue(!watcher.isAlive());
+	}
+
+	@Test
+	public void testFileAdded() throws Exception {
+		CountDownLatch lock = new CountDownLatch(1);
+		final AtomicBoolean notifiedDeleted = new AtomicBoolean(false);
+		final AtomicBoolean notifiedAdded = new AtomicBoolean(false);
+		final AtomicBoolean notifiedModified = new AtomicBoolean(false);
+		FileSystemNIOWatcher watcher = new FileSystemNIOWatcher(Duration.ofMillis(10),
+				Duration.ofMillis(0));
+		watcher.addSourceFolder(temporaryFolder.getRoot());
+		watcher.addListener(new FileChangeListener() {
+			@Override
+			public void onChange(Set<ChangedFiles> changeSet) {
+				for (ChangedFiles set : changeSet) {
+					Set<ChangedFile> files = set.getFiles();
+					for (ChangedFile f : files) {
+
+						if (notifiedModified.get()) {
+							File file = f.getFile();
+							Type type = f.getType();
+							logger.debug("File: " + file + ", type: " + type);
+							assertTrue(!file.exists());
+							assertTrue(type.equals(Type.DELETE));
+							notifiedDeleted.set(true);
+						}
+						else if (notifiedAdded.get()) {
+							File file = f.getFile();
+							Type type = f.getType();
+							logger.debug("File: " + file + ", type: " + type);
+							assertTrue(type.equals(Type.MODIFY));
+							notifiedModified.set(true);
+							file.delete();
+						}
+						else {
+							File file = f.getFile();
+							Type type = f.getType();
+							logger.debug("File: " + file + ", type: " + type);
+							assertTrue(file.exists());
+							assertTrue(type.equals(Type.ADD));
+							notifiedAdded.set(true);
+						}
+					}
+				}
+			}
+		});
+		watcher.start();
+		lock.await(10, TimeUnit.MILLISECONDS);
+		File file = createNewFile("abc", new Date().getTime());
+		assertTrue(file.exists());
+		lock.await(1000, TimeUnit.MILLISECONDS);
+		assertTrue(notifiedModified.get());
+		watcher.stop();
+	}
+
+	private File createNewFile(String content, long lastModified) throws IOException {
+		File file = this.temporaryFolder.newFile();
+		setupFile(file, content, lastModified);
+		return file;
+	}
+
+	private void setupFile(File file, String content, long lastModified)
+			throws IOException {
+		FileCopyUtils.copy(content.getBytes(), file);
+		file.setLastModified(lastModified);
+		logger.debug("New tmp file  : " + file.exists() + ", " + file.getAbsolutePath());
+	}
+
+}


### PR DESCRIPTION
Introduces new interface and a new class FileSystemNIOWatcher. It doesn't require any file system snapshots and it can wait for file change - it doesn't need to check every file every second. It would be a great impact on CPU and RAM usage when you have a lot of files in your project.
Property spring.devtools.restart.nio=true needs to be set on application.properties.
I can see that there is a FileFilter in FileSystemWatcher that would probably allow for filtering files that can trigger restart or reload. I have copied it to FileSystemNIOWatcher. There is an interface FileWatcher. I would be nice if FileSystemWatcher implements it.
Fixes gh-9882