### PR TITLE
FileSystemWatcher alternative - performance improvement

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -67,13 +67,12 @@ public class DevToolsProperties {
 		 * Enable automatic restart.
 		 */
 		private boolean enabled = true;
-		
 
 		/**
 		 * Use asynchronous java.nio API instead of monitoring in intervals.
 		 */
 		private boolean nio = false;
-		
+
 		/**
 		 * Patterns that should be excluded from triggering a full restart.
 		 */
@@ -115,7 +114,7 @@ public class DevToolsProperties {
 		}
 
 		public boolean isNio() {
-			return nio;
+			return this.nio;
 		}
 
 		public void setNio(boolean nio) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -162,7 +162,7 @@ public class LocalDevToolsAutoConfiguration {
 			initWatcher(restartProperties, watcher);
 			return watcher;
 		}
-		
+
 		private void initWatcher(Restart restartProperties, FileSystemWatcher watcher) {
 			String triggerFile = restartProperties.getTriggerFile();
 			if (StringUtils.hasLength(triggerFile)) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileWatcher.java
@@ -18,11 +18,10 @@ package org.springframework.boot.devtools.filewatch;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
 
 /**
- * Allows to watch for changes in source directories
- * 
+ * Allows to watch for changes in source directories.
+ *
  * @author Damian Suchodolski
  *
  */
@@ -57,7 +56,6 @@ public interface FileWatcher {
 
 	/**
 	 * Start monitoring the source folder for changes.
-	 * @throws IOException
 	 */
 	void start();
 
@@ -65,5 +63,4 @@ public interface FileWatcher {
 	 * Stop monitoring the source folders.
 	 */
 	void stop();
-
 }

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcherTest.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemNIOWatcherTest.java
@@ -1,6 +1,20 @@
-package org.springframework.boot.devtools.filewatch;
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertTrue;
+package org.springframework.boot.devtools.filewatch;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,14 +30,25 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 import org.springframework.boot.devtools.filewatch.ChangedFile.Type;
 import org.springframework.boot.devtools.remote.client.ClassPathChangeUploader;
 import org.springframework.util.FileCopyUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base tests for FileSystemNIOWatcher.
+ * @author Damian Suchodolski
+ *
+ */
 public class FileSystemNIOWatcherTest {
 
 	private static final Log logger = LogFactory.getLog(ClassPathChangeUploader.class);
 
+	/**
+	 * Temp folder for tests.
+	 */
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -32,14 +57,14 @@ public class FileSystemNIOWatcherTest {
 		CountDownLatch lock = new CountDownLatch(1);
 		FileSystemNIOWatcher watcher = new FileSystemNIOWatcher(Duration.ofMillis(10),
 				Duration.ofMillis(0));
-		watcher.addSourceFolder(temporaryFolder.getRoot());
-		assertTrue(!watcher.isAlive());
+		watcher.addSourceFolder(this.temporaryFolder.getRoot());
+		assertThat(!watcher.isAlive());
 		watcher.start();
 		lock.await(10, TimeUnit.MILLISECONDS);
-		assertTrue(watcher.isAlive());
+		assertThat(watcher.isAlive());
 		watcher.stop();
 		lock.await(10, TimeUnit.MILLISECONDS);
-		assertTrue(!watcher.isAlive());
+		assertThat(!watcher.isAlive());
 	}
 
 	@Test
@@ -50,7 +75,7 @@ public class FileSystemNIOWatcherTest {
 		final AtomicBoolean notifiedModified = new AtomicBoolean(false);
 		FileSystemNIOWatcher watcher = new FileSystemNIOWatcher(Duration.ofMillis(10),
 				Duration.ofMillis(0));
-		watcher.addSourceFolder(temporaryFolder.getRoot());
+		watcher.addSourceFolder(this.temporaryFolder.getRoot());
 		watcher.addListener(new FileChangeListener() {
 			@Override
 			public void onChange(Set<ChangedFiles> changeSet) {
@@ -62,15 +87,15 @@ public class FileSystemNIOWatcherTest {
 							File file = f.getFile();
 							Type type = f.getType();
 							logger.debug("File: " + file + ", type: " + type);
-							assertTrue(!file.exists());
-							assertTrue(type.equals(Type.DELETE));
+							assertThat(!file.exists());
+							assertThat(type.equals(Type.DELETE));
 							notifiedDeleted.set(true);
 						}
 						else if (notifiedAdded.get()) {
 							File file = f.getFile();
 							Type type = f.getType();
 							logger.debug("File: " + file + ", type: " + type);
-							assertTrue(type.equals(Type.MODIFY));
+							assertThat(type.equals(Type.MODIFY));
 							notifiedModified.set(true);
 							file.delete();
 						}
@@ -78,8 +103,8 @@ public class FileSystemNIOWatcherTest {
 							File file = f.getFile();
 							Type type = f.getType();
 							logger.debug("File: " + file + ", type: " + type);
-							assertTrue(file.exists());
-							assertTrue(type.equals(Type.ADD));
+							assertThat(file.exists());
+							assertThat(type.equals(Type.ADD));
 							notifiedAdded.set(true);
 						}
 					}
@@ -89,9 +114,9 @@ public class FileSystemNIOWatcherTest {
 		watcher.start();
 		lock.await(10, TimeUnit.MILLISECONDS);
 		File file = createNewFile("abc", new Date().getTime());
-		assertTrue(file.exists());
+		assertThat(file.exists());
 		lock.await(1000, TimeUnit.MILLISECONDS);
-		assertTrue(notifiedModified.get());
+		assertThat(notifiedModified.get());
 		watcher.stop();
 	}
 


### PR DESCRIPTION
Checkstyle fixes.
Introduces new interface and a new class FileSystemNIOWatcher. It doesn't require any file system snapshots and it can wait for file change - it doesn't need to check every file every second. It would be a great impact on CPU and RAM usage when you have a lot of files in your project.
Property spring.devtools.restart.nio=true needs to be set on application.properties.
I can see that there is a FileFilter in FileSystemWatcher that would probably allow for filtering files that can trigger restart or reload. I have copied it to FileSystemNIOWatcher. There is an interface FileWatcher. I would be nice if FileSystemWatcher implements it.
Fixes gh-9882